### PR TITLE
修复详情显示和爬虫多次被重复加载

### DIFF
--- a/app/src/main/java/com/github/catvod/crawler/JarLoader.java
+++ b/app/src/main/java/com/github/catvod/crawler/JarLoader.java
@@ -75,7 +75,7 @@ public class JarLoader {
 
     public Spider getSpider(String key, String ext) {
         String clsKey = key.replace("csp_", "");
-        if (spiders.contains(clsKey))
+        if (spiders.containsKey(clsKey))
             return spiders.get(clsKey);
         if (classLoader == null)
             return new SpiderNull();

--- a/app/src/main/java/com/github/tvbox/osc/ui/activity/DetailActivity.java
+++ b/app/src/main/java/com/github/tvbox/osc/ui/activity/DetailActivity.java
@@ -256,6 +256,12 @@ public class DetailActivity extends BaseActivity {
 
                     tvName.setText(mVideo.name);
                     tvSite.setText(Html.fromHtml(getHtml("来源：", mVideo.sourceKey)));
+                    for (SourceBean sourceBean : ApiConfig.get().getSourceBeanList()) {
+                        if (sourceBean.getKey().equals(mVideo.sourceKey)) {
+                            tvSite.setText(Html.fromHtml(getHtml("来源：", sourceBean.getName())));
+                            break;
+                        }
+                    }
                     tvYear.setText(Html.fromHtml(getHtml("年份：", String.valueOf(mVideo.year))));
                     tvArea.setText(Html.fromHtml(getHtml("地区：", mVideo.area)));
                     tvLang.setText(Html.fromHtml(getHtml("语言：", mVideo.lang)));
@@ -325,6 +331,9 @@ public class DetailActivity extends BaseActivity {
     }
 
     private String getHtml(String label, String content) {
+        if (content == null) {
+            content = "";
+        }
         return label + "<font color=\"#FFFFFF\">" + content + "</font>";
     }
 


### PR DESCRIPTION
1. 修复详情来源显示Name而不是Key
2.修复详情中html字符串拼接导致null会拼接成“null”字符串