### PR TITLE
FIX：修复爬虫缓存获取异常

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,9 @@ lint/tmp/
 /LTDecodeSpace
 /adb.exe
 /LTDecodeNew3.exe
+
+
+.DS_Store
+.idea
+app/release
+app/debug

--- a/app/src/main/java/com/github/catvod/crawler/JarLoader.java
+++ b/app/src/main/java/com/github/catvod/crawler/JarLoader.java
@@ -24,7 +24,7 @@ public class JarLoader {
     /**
      * 不要在主线程调用我
      *
-     * @param jarData
+     * @param cache
      */
     public boolean load(String cache) {
         spiders.clear();
@@ -66,16 +66,16 @@ public class JarLoader {
         return success;
     }
 
-    public Spider getSpider(String key, String ext) {
-        String clsKey = key.replace("csp_", "");
-        if (spiders.containsKey(clsKey))
-            return spiders.get(clsKey);
+    public Spider getSpider(String key, String api, String ext) {
+        String clsApi = api.replace("csp_", "");
+        if (spiders.containsKey(key))
+            return spiders.get(key);
         if (classLoader == null)
             return new SpiderNull();
         try {
-            Spider sp = (Spider) classLoader.loadClass("com.github.catvod.spider." + clsKey).newInstance();
+            Spider sp = (Spider) classLoader.loadClass("com.github.catvod.spider." + clsApi).newInstance();
             sp.init(App.getInstance(), ext);
-            spiders.put(clsKey, sp);
+            spiders.put(key, sp);
             return sp;
         } catch (Throwable th) {
             th.printStackTrace();

--- a/app/src/main/java/com/github/tvbox/osc/api/ApiConfig.java
+++ b/app/src/main/java/com/github/tvbox/osc/api/ApiConfig.java
@@ -296,8 +296,7 @@ public class ApiConfig {
                 ChannelGroup channelGroup = new ChannelGroup();
                 channelGroup.setGroupName(url);
                 channelGroupList.add(channelGroup);
-            }
-            else{
+            } else {
                 loadLives(infoJson.get("lives").getAsJsonArray());
             }
         } catch (Throwable th) {
@@ -338,8 +337,7 @@ public class ApiConfig {
         }
     }
 
-    public void loadLives(JsonArray livesArray)
-    {
+    public void loadLives(JsonArray livesArray) {
         int groupIndex = 0;
         int channelIndex = 0;
         for (JsonElement groupElement : livesArray) {
@@ -364,7 +362,7 @@ public class ApiConfig {
     }
 
     public Spider getCSP(SourceBean sourceBean) {
-        return jarLoader.getSpider(sourceBean.getApi(), sourceBean.getExt());
+        return jarLoader.getSpider(sourceBean.getKey(), sourceBean.getApi(), sourceBean.getExt());
     }
 
     public Object[] proxyLocal(Map param) {
@@ -439,6 +437,7 @@ public class ApiConfig {
     public List<ChannelGroup> getChannelGroupList() {
         return channelGroupList;
     }
+
     public void setChannelGroupList(List<ChannelGroup> list) {
         channelGroupList.clear();
         channelGroupList.addAll(list);


### PR DESCRIPTION
爬虫缓存应当以key为键，不能以api的类名为键，否则如XPath只会初始一个实例，