### PR TITLE
直播源选中颜色修复

### DIFF
--- a/app/src/main/res/drawable/shape_live_focus.xml
+++ b/app/src/main/res/drawable/shape_live_focus.xml
@@ -2,7 +2,7 @@
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:state_focused="true">
         <shape>
-            <solid android:color="@color/color_99000000" />
+            <solid android:color="@color/color_1890FF" />
         </shape>
     </item>
     <item android:state_focused="false">


### PR DESCRIPTION
在版本合并过程中文件名变化了，导致之前的颜色修改丢失了，抱歉(lll￢ω￢)